### PR TITLE
Entangled Block now accepts wooden chests

### DIFF
--- a/src/main/resources/data/entangled/recipes/block.json
+++ b/src/main/resources/data/entangled/recipes/block.json
@@ -13,7 +13,7 @@
       "item": "minecraft:obsidian"
     },
     "C": {
-      "item": "minecraft:chest"
+      "tag": "forge:chests/wooden"
     }
   },
   "result": {


### PR DESCRIPTION
Instead of only vanilla chest. This improves Quark compatibility.

Attempt 2, with correct branches 😄 