### PR TITLE
Fix deadlock

### DIFF
--- a/src/main/java/com/supermartijn642/entangled/EntangledBlockEntity.java
+++ b/src/main/java/com/supermartijn642/entangled/EntangledBlockEntity.java
@@ -41,14 +41,13 @@ public class EntangledBlockEntity extends BaseBlockEntity implements TickableBlo
         super(Entangled.tile, pos, state);
     }
 
-    private void updateBoundBlockData(boolean forceLoad) {
+    private void updateBoundBlockData(boolean forceLoad){
         if(this.level == null || this.level.isClientSide || !this.bound || this.boundPos == null)
             return;
 
         Level level = this.getBoundDimension();
         if(level == null)
             return;
-
         ChunkSource chunkSource = level.getChunkSource();
         if(chunkSource instanceof ServerChunkCache && ((ServerChunkCache)chunkSource).mainThread != Thread.currentThread())
             return;

--- a/src/main/java/com/supermartijn642/entangled/EntangledBlockEntity.java
+++ b/src/main/java/com/supermartijn642/entangled/EntangledBlockEntity.java
@@ -15,8 +15,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkSource;
-import net.minecraft.world.level.chunk.ChunkStatus;
-import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 
@@ -52,16 +50,14 @@ public class EntangledBlockEntity extends BaseBlockEntity implements TickableBlo
             return;
 
         ChunkSource chunkSource = level.getChunkSource();
-        if(chunkSource instanceof ServerChunkCache serverChunkCache && serverChunkCache.mainThread != Thread.currentThread())
+        if(chunkSource instanceof serverChunkCache && ((ServerChunkCache)serverChunkCache).mainThread != Thread.currentThread())
             return;
 
-        LevelChunk ourChunk = chunkSource.getChunkNow(SectionPos.blockToSectionCoord(this.boundPos.getX()), SectionPos.blockToSectionCoord(this.boundPos.getZ()));
-
         boolean sendUpdate = false;
-        if(ourChunk != null) {
+        if(forceLoad || chunkSource.getChunkNow(SectionPos.blockToSectionCoord(this.boundPos.getX()), SectionPos.blockToSectionCoord(this.boundPos.getZ())) != null){
             // Get the block and entity
-            BlockState state = ourChunk.getBlockState(this.boundPos);
-            BlockEntity entity = ourChunk.getBlockEntity(this.boundPos);
+            BlockState state = level.getBlockState(this.boundPos);
+            BlockEntity entity = level.getBlockEntity(this.boundPos);
             // Check redstone stuff
             int analogOutputSignal = state.hasAnalogOutputSignal() ?
                 state.getAnalogOutputSignal(level, this.boundPos) : 0;

--- a/src/main/java/com/supermartijn642/entangled/EntangledBlockEntity.java
+++ b/src/main/java/com/supermartijn642/entangled/EntangledBlockEntity.java
@@ -50,7 +50,7 @@ public class EntangledBlockEntity extends BaseBlockEntity implements TickableBlo
             return;
 
         ChunkSource chunkSource = level.getChunkSource();
-        if(chunkSource instanceof chunkSource && ((ServerChunkCache)chunkSource).mainThread != Thread.currentThread())
+        if(chunkSource instanceof ServerChunkCache && ((ServerChunkCache)chunkSource).mainThread != Thread.currentThread())
             return;
 
         boolean sendUpdate = false;

--- a/src/main/java/com/supermartijn642/entangled/EntangledBlockEntity.java
+++ b/src/main/java/com/supermartijn642/entangled/EntangledBlockEntity.java
@@ -50,7 +50,7 @@ public class EntangledBlockEntity extends BaseBlockEntity implements TickableBlo
             return;
 
         ChunkSource chunkSource = level.getChunkSource();
-        if(chunkSource instanceof serverChunkCache && ((ServerChunkCache)serverChunkCache).mainThread != Thread.currentThread())
+        if(chunkSource instanceof chunkSource && ((ServerChunkCache)chunkSource).mainThread != Thread.currentThread())
             return;
 
         boolean sendUpdate = false;


### PR DESCRIPTION
Fixes #66 

Uses `LevelChunk` retrieved through `getChunkNow` to prevent spawning a future when we are already executing that exact future.

This functionality disables the `forceLoad` parameter, which I can't quite determine the use of. All I know is this stops my server from crashing and doesn't break any functionality that I can see.

Also improved readability of the thread checking by changing the cast to the `instanceof` assignment