### PR TITLE
Fix to allow placement of bound entangled blocks

### DIFF
--- a/src/main/java/com/supermartijn642/entangled/EntangledBlock.java
+++ b/src/main/java/com/supermartijn642/entangled/EntangledBlock.java
@@ -141,8 +141,8 @@ public class EntangledBlock extends BaseBlock implements EntityHoldingBlock {
         if(compound.getBoolean("bound")){
             ResourceLocation placeDimension = context.getLevel().dimension().location();
             BlockPos placePos = context.getClickedPos();
-            ResourceLocation targetDimension = EntangledBinderItem.getBoundDimension(stack);
-            BlockPos targetPos = EntangledBinderItem.getBoundPosition(stack);
+            ResourceLocation targetDimension = new ResourceLocation(compound.getString("dimension"));
+            BlockPos targetPos = new BlockPos(compound.getInt("boundx"), compound.getInt("boundy"), compound.getInt("boundz"));
             if(!canBindTo(placeDimension, placePos, targetDimension, targetPos)){
                 Player player = context.getPlayer();
                 if(player != null){


### PR DESCRIPTION
Fix #71

The reason blocks could not be re-placed was because the NBT hierarchy containing positions and dimensions differs between Entangled Binder and Entangled Block.

This pull request fixes the issue by retrieving the data from the proper NBT hierarchy.