### PR TITLE
Fix to crash when mouse over a bound Entangled block and binder

### DIFF
--- a/src/main/java/com/supermartijn642/entangled/EntangledBinderItem.java
+++ b/src/main/java/com/supermartijn642/entangled/EntangledBinderItem.java
@@ -100,7 +100,7 @@ public class EntangledBinderItem extends BaseItem {
             NBTTagCompound tag = stack.getTagCompound();
             int x = tag.getInteger("boundx"), y = tag.getInteger("boundy"), z = tag.getInteger("boundz");
             ITextComponent dimension = DimensionManager.isDimensionRegistered(tag.getInteger("dimension")) ?
-                TextComponents.dimension(DimensionManager.getProvider(tag.getInteger("dimension")).getDimensionType()).color(TextFormatting.GOLD).get() :
+                TextComponents.dimension(DimensionManager.getProviderType(tag.getInteger("dimension"))).color(TextFormatting.GOLD).get() :
                 TextComponents.number(tag.getInteger("dimension")).color(TextFormatting.RED).get();
             ITextComponent xText = TextComponents.string(Integer.toString(x)).color(TextFormatting.GOLD).get();
             ITextComponent yText = TextComponents.string(Integer.toString(y)).color(TextFormatting.GOLD).get();

--- a/src/main/java/com/supermartijn642/entangled/EntangledBlock.java
+++ b/src/main/java/com/supermartijn642/entangled/EntangledBlock.java
@@ -129,7 +129,7 @@ public class EntangledBlock extends BaseBlock implements EntityHoldingBlock {
         if(tag.hasKey("bound") && tag.getBoolean("bound")){
             int x = tag.getInteger("boundx"), y = tag.getInteger("boundy"), z = tag.getInteger("boundz");
             ITextComponent dimension = DimensionManager.isDimensionRegistered(tag.getInteger("dimension")) ?
-                TextComponents.dimension(DimensionManager.getProvider(tag.getInteger("dimension")).getDimensionType()).color(TextFormatting.GOLD).get() :
+                TextComponents.dimension(DimensionManager.getProviderType(tag.getInteger("dimension"))).color(TextFormatting.GOLD).get() :
                 TextComponents.number(tag.getInteger("dimension")).color(TextFormatting.RED).get();
             ITextComponent name = TextComponents.blockState(Block.getStateById(tag.getInteger("blockstate"))).color(TextFormatting.GOLD).get();
             ITextComponent xText = TextComponents.string(Integer.toString(x)).color(TextFormatting.GOLD).get();


### PR DESCRIPTION
Fix #82

I am not well-versed in modding for Minecraft 1.12.2, so I couldn't identify the exact cause.

However, after reviewing the implementation of `DimensionManager`, I noticed that [DimensionManager#getProviderType](https://github.com/MinecraftForge/MinecraftForge/blob/d3f01843f7e7a4f613b5e8113d381fd8747b4343/src/main/java/net/minecraftforge/common/DimensionManager.java#L166) is implemented to always return a `DimensionType` when the return value of [DimensionManager#isDimensionRegistered](https://github.com/MinecraftForge/MinecraftForge/blob/d3f01843f7e7a4f613b5e8113d381fd8747b4343/src/main/java/net/minecraftforge/common/DimensionManager.java#L155-L158) is `true`.

Therefore, I used it as a substitute for `DimensionManager#getProvider`.
